### PR TITLE
adds support for cloudbeaver

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Here resides the v2 version of the [goeuropean.org](https://www.goeuropean.org)
 website.
 
-
 # Contributors
 
 If you are a contributor, it's good that you familiarise yourself with the
@@ -11,22 +10,38 @@ README, and there are loads of useful information in the
 [CONTRIBUTING.md](./CONTRIBUTING.md) to setup your development environment for
 example.
 
-
 # Prerequisites
 
 ## TODO software prerequisites
 
 ## TODO third party prerequisites
 
-
 # TODO Build
 
 ## TODO Build locally
 
-## TODO Build docker
+## Build docker
 
+In order to build and run the project locally:
+
+1. copy the content of the file `.env.example` to a new file called `.env`: `cp .env.example .env`
+2. build and run the docker containers: `docker compose up -d`
+
+- if you want to inspect the internal DB run this command instead: `docker compose -f docker-compose.yml -f docker-compose.local.yml up -d`,
+  this will spin up also a _cloudBeaver_ instance.
+
+### Connecting to the local DB
+
+Once you build and start the application using `docker compose -f docker-compose.yml -f docker-compose.local.yml up -d`,
+connect to `localhost:8978` and create a new admin user (this is just a cloudBeaver user -- pick any username/password you like).
+After creating the user and logging in you can add the application database:
+
+- click on the `+` sign at the top-left of the screen
+- click on `find database`
+- type localhost in the input field and press enter, a database should now appear in the list
+- click on the database and configure it according to the values in the `.env` file, by default:
+  - database: cms
+  - user password: cms
+  - user name: cms
 
 # TODO Configuration
-
-
-

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,30 @@
+
+services:
+  payload:
+    networks:
+      - local
+
+  postgres:
+    ports:
+      - "5432:5432"
+    networks:
+      - local
+
+
+  cloudbeaver:
+    image: dbeaver/cloudbeaver:latest
+    container_name: "cloudbeaver"
+    restart: always
+    ports:
+      - '8978:8978'
+    volumes:
+      - cloudbeaver:/opt/cloudbeaver/workspace
+    networks:
+      - local
+
+volumes:
+  cloudbeaver:
+
+networks:
+  local:
+    driver: bridge


### PR DESCRIPTION
# Description
run `docker compose -f docker-compose.yml -f docker-compose.local.yml up`
the service will be exposed at `localhost:8978` create a user, login and click on `find database` fill out form and connect.

# Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that might break existing functionality)

# Related Issue(s)
Fixes #56 

# Checklist
- [ ] The database seeding still works ([src/endpoints/seed/index.ts](../src/endpoints/seed/index.ts)).
- [ ] My code follows the project's style guidelines.
- [ ] I have performed a self-review of my code.
- [ ] I have commented on complex code areas.
- [ ] I have added necessary documentation.
- [ ] All tests pass (or tests have been added if needed).

