### PR TITLE
feature: add team block

### DIFF
--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -8,6 +8,7 @@ import { FormBlock } from '@/blocks/Form/Component'
 import { MediaBlock } from '@/blocks/MediaBlock/Component'
 import { ProductsListBlock } from './ProductList/Component'
 import { FAQBlock } from './FAQ/Component'
+import { TeamBlock } from './Team/Component'
 
 // key has to be same as the slug name
 const blockComponents = {
@@ -16,7 +17,8 @@ const blockComponents = {
   formBlock: FormBlock,
   mediaBlock: MediaBlock,
   productsList: ProductsListBlock,
-  faq: FAQBlock
+  faq: FAQBlock,
+  team: TeamBlock,
 }
 
 export const RenderBlocks: React.FC<{

--- a/src/blocks/Team/Component.tsx
+++ b/src/blocks/Team/Component.tsx
@@ -1,0 +1,35 @@
+import type { TeamBlock as TeamBlockProps } from 'src/payload-types'
+import React from 'react'
+import { Paragraph, H3 } from '@/components/ui/typography'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Media } from '@/components/Media'
+
+type Props = TeamBlockProps
+
+export const TeamBlock: React.FC<Props> = ({ title, subtitle, members }) => {
+  return (
+    <section className="mx-auto my-12 max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div className="mb-10 text-center">
+        <H3>{title}</H3>
+        {subtitle && <Paragraph>{subtitle}</Paragraph>}
+      </div>
+      <div className="grid grid-cols-1 gap-4 lg:gap-8 sm:grid-cols-2 md:grid-cols-3 max-w-5xl mx-auto justify-items-center">
+        {members?.map((member) => (
+          <Card key={member.name} className="rounded-xl max-w-80 py-4">
+            <CardHeader className="flex flex-col items-center">
+              <Media
+                imgClassName="h-32 w-32 border border-border rounded-full object-cover bg-background mb-4"
+                resource={member.image}
+              />
+              <CardTitle>{member.name}</CardTitle>
+              <CardDescription>{member.title}</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Paragraph className="text-center">{member.quote}</Paragraph>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/blocks/Team/config.ts
+++ b/src/blocks/Team/config.ts
@@ -1,0 +1,54 @@
+import type { Block } from 'payload'
+
+export const Team: Block = {
+  slug: 'team',
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      label: 'Section Title',
+      required: true,
+      defaultValue: 'Our team',
+    },
+    {
+      name: 'subtitle',
+      type: 'textarea',
+      label: 'Section Subtitle',
+      defaultValue:
+        "Go European would not be possible without the project's dozens of incredible volunteers.",
+    },
+    {
+      name: 'members',
+      type: 'array',
+      label: 'Team Members',
+      minRows: 1,
+      fields: [
+        {
+          name: 'image',
+          type: 'upload',
+          relationTo: 'media',
+          label: 'Profile Picture',
+          required: true,
+        },
+        {
+          name: 'name',
+          type: 'text',
+          label: 'Name',
+          required: true,
+        },
+        {
+          name: 'title',
+          type: 'text',
+          label: 'Title/Role',
+          required: true,
+        },
+        {
+          name: 'quote',
+          type: 'textarea',
+          label: 'Quote/Description',
+        },
+      ],
+    },
+  ],
+  interfaceName: 'TeamBlock',
+}

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -23,6 +23,7 @@ import {
   OverviewField,
   PreviewField,
 } from '@payloadcms/plugin-seo/fields'
+import { Team } from '@/blocks/Team/config'
 
 export const Pages: CollectionConfig<'pages'> = {
   slug: 'pages',
@@ -78,14 +79,7 @@ export const Pages: CollectionConfig<'pages'> = {
             {
               name: 'layout',
               type: 'blocks',
-              blocks: [
-                CallToAction,
-                Content,
-                MediaBlock,
-                FormBlock,
-                ProductsListBlock,
-                FAQ
-              ],
+              blocks: [CallToAction, Content, MediaBlock, FormBlock, ProductsListBlock, FAQ, Team],
               required: true,
               admin: {
                 initCollapsed: true,

--- a/src/components/ui/typography.tsx
+++ b/src/components/ui/typography.tsx
@@ -1,0 +1,64 @@
+import { cn } from '@/utilities/ui'
+
+export function H1({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <h1 className={cn('scroll-m-20 text-4xl font-extrabold tracking-tight lg:text-5xl', className)}>
+      {children}
+    </h1>
+  )
+}
+export function H2({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <h2
+      className={cn('scroll-m-20 pb-2 text-3xl font-semibold tracking-tight first:mt-0', className)}
+    >
+      {children}
+    </h2>
+  )
+}
+
+export function H3({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <h3 className={cn('scroll-m-20 text-2xl font-semibold tracking-tight', className)}>
+      {children}
+    </h3>
+  )
+}
+
+export function H4({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <h4 className={cn('scroll-m-20 text-xl font-semibold tracking-tight', className)}>
+      {children}
+    </h4>
+  )
+}
+
+export function Paragraph({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  return <p className={cn('leading-7 [&:not(:first-child)]:mt-6', className)}>{children}</p>
+}
+
+export function Blockquote({
+  children,
+  className,
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  return (
+    <blockquote className={cn('mt-6 border-l-2 pl-6 italic', className)}>{children}</blockquote>
+  )
+}
+
+export function List({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <ul className={cn('my-6 ml-6 list-disc [&>li]:mt-2', className)}>{children}</ul>
+}
+
+export function Muted({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <p className={cn('text-sm text-muted-foreground', className)}>{children}</p>
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -239,7 +239,7 @@ export interface Page {
       | null;
     media?: (number | null) | Media;
   };
-  layout: (CallToActionBlock | ContentBlock | MediaBlock | FormBlock | ProductsList | FAQBlock)[];
+  layout: (CallToActionBlock | ContentBlock | MediaBlock | FormBlock | ProductsList | FAQBlock | TeamBlock)[];
   meta?: {
     title?: string | null;
     /**
@@ -714,6 +714,26 @@ export interface FAQBlock {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TeamBlock".
+ */
+export interface TeamBlock {
+  title: string;
+  subtitle?: string | null;
+  members?:
+    | {
+        image: number | Media;
+        name: string;
+        title: string;
+        quote?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'team';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "categories".
  */
 export interface Category {
@@ -1159,6 +1179,7 @@ export interface PagesSelect<T extends boolean = true> {
         formBlock?: T | FormBlockSelect<T>;
         productsList?: T | ProductsListSelect<T>;
         faq?: T | FAQBlockSelect<T>;
+        team?: T | TeamBlockSelect<T>;
       };
   meta?:
     | T
@@ -1263,6 +1284,25 @@ export interface FAQBlockSelect<T extends boolean = true> {
     | {
         question?: T;
         answer?: T;
+        id?: T;
+      };
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TeamBlock_select".
+ */
+export interface TeamBlockSelect<T extends boolean = true> {
+  title?: T;
+  subtitle?: T;
+  members?:
+    | T
+    | {
+        image?: T;
+        name?: T;
+        title?: T;
+        quote?: T;
         id?: T;
       };
   id?: T;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -196,7 +196,7 @@ export default buildConfig({
     ReplacedProducts,
     Companies,
     Brands,
-    Countries
+    Countries,
   ],
   cors: [getServerSideURL()].filter(Boolean),
   globals: [Header, Footer],


### PR DESCRIPTION
# Description
- adds Team Block component including config
- adds reusable Typography components into src/components/ui

Team Block (using shadcn/ui)
![img_qFI1YBXM](https://github.com/user-attachments/assets/55447bc6-1d96-4a62-8643-58e01028d651)

# Type of Change
- [x] New feature (non-breaking change that adds functionality)

# Related Issue(s)
Fixes #54 

# Checklist
- [x] The database seeding still works ([src/endpoints/seed/index.ts](../src/endpoints/seed/index.ts)).
- [ ] My code follows the project's style guidelines.
- [x] I have performed a self-review of my code.
- [ ] I have commented on complex code areas.
- [ ] I have added necessary documentation.
- [ ] All tests pass (or tests have been added if needed). (**_do we have tests yet?)_**

