### PR TITLE
feat: stats block

### DIFF
--- a/src/blocks/RenderBlocks.tsx
+++ b/src/blocks/RenderBlocks.tsx
@@ -9,6 +9,7 @@ import { MediaBlock } from '@/blocks/MediaBlock/Component'
 import { ProductsListBlock } from './ProductList/Component'
 import { FAQBlock } from './FAQ/Component'
 import { TeamBlock } from './Team/Component'
+import { StatsBlock } from './Stats/Component'
 
 // key has to be same as the slug name
 const blockComponents = {
@@ -19,6 +20,7 @@ const blockComponents = {
   productsList: ProductsListBlock,
   faq: FAQBlock,
   team: TeamBlock,
+  stats: StatsBlock,
 }
 
 export const RenderBlocks: React.FC<{

--- a/src/blocks/Stats/Component.tsx
+++ b/src/blocks/Stats/Component.tsx
@@ -3,15 +3,84 @@ import React from 'react'
 import { Paragraph, H3, H4, Muted } from '@/components/ui/typography'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
 import { Icon } from '@/components/Icon'
+import { getPayload } from 'payload'
+import configPromise from '@payload-config'
+
+async function getProductCount() {
+  const payload = await getPayload({ config: configPromise })
+  const products = await payload.find({
+    collection: 'eu-products',
+  })
+  const productCount = products.docs.length
+
+  return productCount
+}
 
 type Props = StatsBlockProps
+type Stat = {
+  icon:
+    | 'Activity'
+    | 'AlertCircle'
+    | 'Award'
+    | 'BarChart'
+    | 'CheckCircle'
+    | 'DollarSign'
+    | 'Euro'
+    | 'Heart'
+    | 'Home'
+    | 'Map'
+    | 'ShoppingBag'
+    | 'Star'
+    | 'ThumbsUp'
+    | 'Trophy'
+    | 'Users'
+  statType: 'dynamic' | 'custom'
+  number?: number | null
+  suffix?: string | null
+  label: string
+  description: string
+  id?: string | null
+}
 
-export const StatsBlock: React.FC<Props> = ({ title, subtitle, stats }) => {
+const StatCard = async ({ stat }: { stat: Stat }) => {
+  let number = stat.number
+  if (stat.statType === 'dynamic') {
+    const productCount = await getProductCount()
+    number = productCount
+  }
+
+  return (
+    <Card
+      key={stat.label}
+      className="border-none bg-transparent shadow-none ring-1 ring-primary/20 hover:shadow-lg hover:border-primary/20 transition-all duration-300 rounded-xl max-w-64 w-full"
+    >
+      <CardHeader className="pb-3 space-y-4">
+        <div className="flex flex-col items-center">
+          {stat.icon && (
+            <div className="rounded-xl p-3 bg-primary/10 ring-1 ring-primary/20 mb-4">
+              <Icon iconName={stat.icon} className="w-7 h-7 text-primary" />
+            </div>
+          )}
+          <div className="text-4xl font-bold tracking-tight">
+            {number}
+            {stat.suffix}
+          </div>
+          <H4 className="mb-1 text-foreground/90 text-center">{stat.label}</H4>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <Muted className="text-base leading-relaxed text-center">{stat.description}</Muted>
+      </CardContent>
+    </Card>
+  )
+}
+
+export const StatsBlock: React.FC<Props> = async ({ title, subtitle, stats }) => {
   return (
     <section className="relative py-24 px-4 sm:px-6 lg:px-8 bg-gradient-to-b from-background to-background/95 overflow-hidden">
       <div className="absolute inset-0 bg-grid-white/10 bg-[size:20px_20px] [mask-image:radial-gradient(white,transparent_70%)]" />
 
-      <div className="relative max-w-7xl mx-auto mb-16 text-center">
+      <div className="relative max-w-7xl mx-auto mb-12 text-center">
         <H3 className="mb-4 bg-clip-text text-transparent bg-gradient-to-r from-primary to-primary/80">
           {title}
         </H3>
@@ -21,30 +90,7 @@ export const StatsBlock: React.FC<Props> = ({ title, subtitle, stats }) => {
       </div>
 
       <div className="relative flex flex-wrap gap-8 max-w-5xl mx-auto justify-center">
-        {stats?.map((stat) => (
-          <Card
-            key={stat.label}
-            className="h-full border-none bg-transparent shadow-none ring-1 ring-primary/20 hover:shadow-lg hover:border-primary/20 transition-all duration-300 rounded-xl max-w-64 w-full"
-          >
-            <CardHeader className="pb-3 space-y-4">
-              <div className="flex flex-col items-center">
-                {stat.icon && (
-                  <div className="rounded-xl p-3 bg-primary/10 ring-1 ring-primary/20 mb-4">
-                    <Icon iconName={stat.icon} className="w-7 h-7 text-primary" />
-                  </div>
-                )}
-                <div className="text-4xl font-bold tracking-tight">
-                  {stat.number}
-                  {stat.suffix}
-                </div>
-                <H4 className="mb-1 text-foreground/90 text-center">{stat.label}</H4>
-              </div>
-            </CardHeader>
-            <CardContent>
-              <Muted className="text-base leading-relaxed text-center">{stat.description}</Muted>
-            </CardContent>
-          </Card>
-        ))}
+        {stats?.map((stat) => <StatCard key={stat.label} stat={stat} />)}
       </div>
     </section>
   )

--- a/src/blocks/Stats/Component.tsx
+++ b/src/blocks/Stats/Component.tsx
@@ -1,26 +1,10 @@
 import type { StatsBlock as StatsBlockProps } from 'src/payload-types'
 import React from 'react'
 import { Paragraph, H3, H4, Muted } from '@/components/ui/typography'
-import * as LucideIcons from 'lucide-react'
 import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Icon } from '@/components/Icon'
 
 type Props = StatsBlockProps
-
-interface LucideIconProps {
-  iconName: string
-  className?: string
-}
-
-export const LucideIcon: React.FC<LucideIconProps> = ({ iconName, className = '' }) => {
-  const icons = LucideIcons as unknown as Record<string, React.FC<{ className?: string }>>
-  const IconComponent = icons[iconName]
-
-  if (IconComponent) {
-    return <IconComponent className={className} />
-  }
-
-  return null
-}
 
 export const StatsBlock: React.FC<Props> = ({ title, subtitle, stats }) => {
   return (
@@ -46,7 +30,7 @@ export const StatsBlock: React.FC<Props> = ({ title, subtitle, stats }) => {
               <div className="flex flex-col items-center">
                 {stat.icon && (
                   <div className="rounded-xl p-3 bg-primary/10 ring-1 ring-primary/20 mb-4">
-                    <LucideIcon iconName={stat.icon} className="w-7 h-7 text-primary" />
+                    <Icon iconName={stat.icon} className="w-7 h-7 text-primary" />
                   </div>
                 )}
                 <div className="text-4xl font-bold tracking-tight">

--- a/src/blocks/Stats/Component.tsx
+++ b/src/blocks/Stats/Component.tsx
@@ -1,0 +1,67 @@
+import type { StatsBlock as StatsBlockProps } from 'src/payload-types'
+import React from 'react'
+import { Paragraph, H3, H4, Muted } from '@/components/ui/typography'
+import * as LucideIcons from 'lucide-react'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+
+type Props = StatsBlockProps
+
+interface LucideIconProps {
+  iconName: string
+  className?: string
+}
+
+export const LucideIcon: React.FC<LucideIconProps> = ({ iconName, className = '' }) => {
+  const icons = LucideIcons as unknown as Record<string, React.FC<{ className?: string }>>
+  const IconComponent = icons[iconName]
+
+  if (IconComponent) {
+    return <IconComponent className={className} />
+  }
+
+  return null
+}
+
+export const StatsBlock: React.FC<Props> = ({ title, subtitle, stats }) => {
+  return (
+    <section className="relative py-24 px-4 sm:px-6 lg:px-8 bg-gradient-to-b from-background to-background/95 overflow-hidden">
+      <div className="absolute inset-0 bg-grid-white/10 bg-[size:20px_20px] [mask-image:radial-gradient(white,transparent_70%)]" />
+
+      <div className="relative max-w-7xl mx-auto mb-16 text-center">
+        <H3 className="mb-4 bg-clip-text text-transparent bg-gradient-to-r from-primary to-primary/80">
+          {title}
+        </H3>
+        {subtitle && (
+          <Paragraph className="max-w-2xl mx-auto text-muted-foreground/90">{subtitle}</Paragraph>
+        )}
+      </div>
+
+      <div className="relative flex flex-wrap gap-8 max-w-5xl mx-auto justify-center">
+        {stats?.map((stat) => (
+          <Card
+            key={stat.label}
+            className="h-full border-none bg-transparent shadow-none ring-1 ring-primary/20 hover:shadow-lg hover:border-primary/20 transition-all duration-300 rounded-xl max-w-64 w-full"
+          >
+            <CardHeader className="pb-3 space-y-4">
+              <div className="flex flex-col items-center">
+                {stat.icon && (
+                  <div className="rounded-xl p-3 bg-primary/10 ring-1 ring-primary/20 mb-4">
+                    <LucideIcon iconName={stat.icon} className="w-7 h-7 text-primary" />
+                  </div>
+                )}
+                <div className="text-4xl font-bold tracking-tight">
+                  {stat.number}
+                  {stat.suffix}
+                </div>
+                <H4 className="mb-1 text-foreground/90 text-center">{stat.label}</H4>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Muted className="text-base leading-relaxed text-center">{stat.description}</Muted>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/blocks/Stats/config.ts
+++ b/src/blocks/Stats/config.ts
@@ -1,0 +1,78 @@
+import type { Block } from 'payload'
+
+export const Stats: Block = {
+  slug: 'stats',
+  labels: {
+    singular: 'Stats Block',
+    plural: 'Stats Blocks',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      label: 'Section Title',
+      required: true,
+      defaultValue: 'About Us',
+    },
+    {
+      name: 'subtitle',
+      type: 'textarea',
+      label: 'Section Subtitle',
+    },
+    {
+      name: 'stats',
+      type: 'array',
+      label: 'Stats',
+      minRows: 1,
+      fields: [
+        {
+          name: 'icon',
+          type: 'select',
+          label: 'Icon',
+          required: true,
+          options: [
+            { label: 'Activity', value: 'Activity' },
+            { label: 'Alert Circle', value: 'AlertCircle' },
+            { label: 'Award', value: 'Award' },
+            { label: 'Bar Chart', value: 'BarChart' },
+            { label: 'Check Circle', value: 'CheckCircle' },
+            { label: 'Dollar Sign', value: 'DollarSign' },
+            { label: 'Euro', value: 'Euro' },
+            { label: 'Heart', value: 'Heart' },
+            { label: 'Home', value: 'Home' },
+            { label: 'Map', value: 'Map' },
+            { label: 'Shopping Bag', value: 'ShoppingBag' },
+            { label: 'Star', value: 'Star' },
+            { label: 'Thumbs Up', value: 'ThumbsUp' },
+            { label: 'Trophy', value: 'Trophy' },
+            { label: 'Users', value: 'Users' },
+          ],
+        },
+        {
+          name: 'number',
+          type: 'number',
+          label: 'Number',
+          required: true,
+        },
+        {
+          name: 'suffix',
+          type: 'text',
+          label: 'Suffix',
+        },
+        {
+          name: 'label',
+          type: 'text',
+          label: 'Label',
+          required: true,
+        },
+        {
+          name: 'description',
+          type: 'text',
+          label: 'Description',
+          required: true,
+        },
+      ],
+    },
+  ],
+  interfaceName: 'StatsBlock',
+}

--- a/src/blocks/Stats/config.ts
+++ b/src/blocks/Stats/config.ts
@@ -48,11 +48,30 @@ export const Stats: Block = {
             { label: 'Users', value: 'Users' },
           ],
         },
+        // Radio button to choose between dynamic and custom stat value
+        {
+          name: 'statType',
+          type: 'radio',
+          options: [
+            {
+              label: 'Dynamic (use product count)',
+              value: 'dynamic',
+            },
+            {
+              label: 'Custom',
+              value: 'custom',
+            },
+          ],
+          defaultValue: 'custom',
+          required: true,
+        },
         {
           name: 'number',
           type: 'number',
-          label: 'Number',
-          required: true,
+          label: 'Value',
+          admin: {
+            condition: (_, siblingData) => siblingData.statType === 'custom',
+          },
         },
         {
           name: 'suffix',

--- a/src/collections/Pages/index.ts
+++ b/src/collections/Pages/index.ts
@@ -24,6 +24,7 @@ import {
   PreviewField,
 } from '@payloadcms/plugin-seo/fields'
 import { Team } from '@/blocks/Team/config'
+import { Stats } from '@/blocks/Stats/config'
 
 export const Pages: CollectionConfig<'pages'> = {
   slug: 'pages',
@@ -79,7 +80,16 @@ export const Pages: CollectionConfig<'pages'> = {
             {
               name: 'layout',
               type: 'blocks',
-              blocks: [CallToAction, Content, MediaBlock, FormBlock, ProductsListBlock, FAQ, Team],
+              blocks: [
+                CallToAction,
+                Content,
+                MediaBlock,
+                FormBlock,
+                ProductsListBlock,
+                FAQ,
+                Team,
+                Stats,
+              ],
               required: true,
               admin: {
                 initCollapsed: true,

--- a/src/components/Icon/index.tsx
+++ b/src/components/Icon/index.tsx
@@ -1,0 +1,17 @@
+import * as LucideIcons from 'lucide-react'
+
+interface IconProps {
+  iconName: string
+  className?: string
+}
+
+export const Icon: React.FC<IconProps> = ({ iconName, className = '' }) => {
+  const icons = LucideIcons as unknown as Record<string, React.FC<{ className?: string }>>
+  const IconComponent = icons[iconName]
+
+  if (IconComponent) {
+    return <IconComponent className={className} />
+  }
+
+  return null
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -766,7 +766,8 @@ export interface StatsBlock {
           | 'ThumbsUp'
           | 'Trophy'
           | 'Users';
-        number: number;
+        statType: 'dynamic' | 'custom';
+        number?: number | null;
         suffix?: string | null;
         label: string;
         description: string;
@@ -1365,6 +1366,7 @@ export interface StatsBlockSelect<T extends boolean = true> {
     | T
     | {
         icon?: T;
+        statType?: T;
         number?: T;
         suffix?: T;
         label?: T;

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -239,7 +239,16 @@ export interface Page {
       | null;
     media?: (number | null) | Media;
   };
-  layout: (CallToActionBlock | ContentBlock | MediaBlock | FormBlock | ProductsList | FAQBlock | TeamBlock)[];
+  layout: (
+    | CallToActionBlock
+    | ContentBlock
+    | MediaBlock
+    | FormBlock
+    | ProductsList
+    | FAQBlock
+    | TeamBlock
+    | StatsBlock
+  )[];
   meta?: {
     title?: string | null;
     /**
@@ -734,6 +743,42 @@ export interface TeamBlock {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "StatsBlock".
+ */
+export interface StatsBlock {
+  title: string;
+  subtitle?: string | null;
+  stats?:
+    | {
+        icon:
+          | 'Activity'
+          | 'AlertCircle'
+          | 'Award'
+          | 'BarChart'
+          | 'CheckCircle'
+          | 'DollarSign'
+          | 'Euro'
+          | 'Heart'
+          | 'Home'
+          | 'Map'
+          | 'ShoppingBag'
+          | 'Star'
+          | 'ThumbsUp'
+          | 'Trophy'
+          | 'Users';
+        number: number;
+        suffix?: string | null;
+        label: string;
+        description: string;
+        id?: string | null;
+      }[]
+    | null;
+  id?: string | null;
+  blockName?: string | null;
+  blockType: 'stats';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "categories".
  */
 export interface Category {
@@ -1180,6 +1225,7 @@ export interface PagesSelect<T extends boolean = true> {
         productsList?: T | ProductsListSelect<T>;
         faq?: T | FAQBlockSelect<T>;
         team?: T | TeamBlockSelect<T>;
+        stats?: T | StatsBlockSelect<T>;
       };
   meta?:
     | T
@@ -1303,6 +1349,26 @@ export interface TeamBlockSelect<T extends boolean = true> {
         name?: T;
         title?: T;
         quote?: T;
+        id?: T;
+      };
+  id?: T;
+  blockName?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "StatsBlock_select".
+ */
+export interface StatsBlockSelect<T extends boolean = true> {
+  title?: T;
+  subtitle?: T;
+  stats?:
+    | T
+    | {
+        icon?: T;
+        number?: T;
+        suffix?: T;
+        label?: T;
+        description?: T;
         id?: T;
       };
   id?: T;


### PR DESCRIPTION
# Description
- adds Stats Block with custom or dynamic value
- dynamic stat value gets product count from db
- adds Icon Component to dynamically render LucideIcon based on icon name set in Admin UI (this component should only be used when dynamic icon rendering is needed, usually direct use of a specific lucide icon is preferred)

Stats Block & Admin settings:
![img_tgOQC7Az](https://github.com/user-attachments/assets/5ab1bdca-081b-497f-84b9-ff93e01999f2)

# Type of Change
- [x] New feature (non-breaking change that adds functionality)

# Related Issue(s)
Fixes #25

# Checklist
- [x] The database seeding still works ([src/endpoints/seed/index.ts](../src/endpoints/seed/index.ts)).
- [ ] My code follows the project's style guidelines.
- [x] I have performed a self-review of my code.
- [x] I have commented on complex code areas.
- [ ] I have added necessary documentation.
- [ ] All tests pass (or tests have been added if needed).

